### PR TITLE
Add draft and work type to generic work

### DIFF
--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -16,6 +16,7 @@ CurationConcerns.configure do |config|
     'Conference Proceeding' => 'Conference Proceeding',
     'Dataset' => 'Dataset',
     'Dissertation' => 'Dissertation',
+    'Fourth Year Thesis' => 'Fourth Year Thesis',
     'Image' => 'Image',
     'Journal' => 'Journal',
     'Map or Cartographic Material' => 'Map or Cartographic Material',

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -21,6 +21,7 @@ Sufia.config do |config|
     "Conference Proceeding" => "Conference Proceeding",
     "Dataset" => "Dataset",
     "Dissertation" => "Dissertation",
+    "Fourth Year Thesis" => "Fourth Year Thesis",
     "Image" => "Image",
     "Journal" => "Journal",
     "Map or Cartographic Material" => "Map or Cartographic Material",

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -44,6 +44,7 @@ Sufia.config do |config|
     "Conference Proceeding" => "http://schema.org/ScholarlyArticle",
     "Dataset" => "http://schema.org/Dataset",
     "Dissertation" => "http://schema.org/ScholarlyArticle",
+    "Fourth Year Thesis" => "http://schema.org/ScholarlyArticle",
     "Image" => "http://schema.org/ImageObject",
     "Journal" => "http://schema.org/CreativeWork",
     "Map or Cartographic Material" => "http://schema.org/Map",

--- a/lib/libra2/app/models/generic_work.rb
+++ b/lib/libra2/app/models/generic_work.rb
@@ -6,8 +6,22 @@ class GenericWork < ActiveFedora::Base
   include Sufia::WorkBehavior
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  # CustomMetadata
+  # Custom Metadata
+  #
+  # work_type - Currently either a 'thesis' or a 'generic_work'.
+  property :work_type, predicate: ::RDF::URI('http://example.org/terms/work_type'), multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  # draft - Pertinent only for 'thesis' work_type.
+  #   True if the thesis is not finalized (i.e. submitted, for whatever the
+  #      term means for the work resource type, (dissertation, masters,
+  #      fourth_year, class, project, etc.)).
+  #   False if the thesis is finalized.
+  #   False for any other work_type other than 'thesis'.
   property :draft, predicate: ::RDF::URI('http://example.org/terms/draft'), multiple: false do |index|
     index.as :stored_searchable
   end
+
+
 end

--- a/lib/libra2/tasks/works.rake
+++ b/lib/libra2/tasks/works.rake
@@ -78,6 +78,8 @@ task create: :environment do |t, args|
     w.date_uploaded = CurationConcerns::TimeService.time_in_utc
     w.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     w.description << description
+    w.work_type = 'generic_work'
+    w.draft = 'false'
 
   end
 
@@ -90,6 +92,36 @@ task create: :environment do |t, args|
   service.ingest_local_file( [ File.basename( filename ) ], work.id )
 
   puts "Created new work (#{title})"
+  task who.to_sym do ; end
+
+end
+
+desc "Create new thesis; libra2:create_thesis <jdoe@virginia.edu>"
+task create_thesis: :environment do |t, args|
+
+  who = ARGV[ 1 ]
+  who = default_email if who.nil?
+
+  time = Time.now
+  upload_set = UploadSet.find_or_create( SecureRandom.uuid )
+  user = User.find_by_email( who )
+  title = "THESIS Generated title for #{who} at #{time}"
+  description = "THESIS Description for #{who} at #{time}"
+
+  work = GenericWork.create!(title: [ title ], upload_set: upload_set) do |w|
+
+    # generic work attributes
+    w.apply_depositor_metadata(user)
+    w.creator << who
+    w.date_uploaded = CurationConcerns::TimeService.time_in_utc
+    w.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    w.description << description
+    w.work_type = 'thesis'
+    w.draft = 'true'
+
+  end
+
+  puts "Created new THESIS (#{title})"
   task who.to_sym do ; end
 
 end


### PR DESCRIPTION
Task [LIBRA-34]  Initialize the 'draft' metadata on a newly created ETD to be 'true'
Part of [LIBRA-17]  As Greg, I can see my draft ETD when I view my dashnoard